### PR TITLE
Update path to Action GetProjects using Url.Action instead of hard coded value.

### DIFF
--- a/TeamCityMonitor/Views/Home/Index.cshtml
+++ b/TeamCityMonitor/Views/Home/Index.cshtml
@@ -29,7 +29,7 @@
         projectsViewModel = {
             projects: ko.observableArray([]),
             loadProjects: function () {
-                var url = "/Home/GetProjects/";
+                var url = '@Url.Action("GetProjects")';
                 $.ajax({
                     url: url,
                     success: function (response) {


### PR DESCRIPTION
Removed hard-coded path to home controller. The hard coded value will not work if the example web app is deployed in any other path on IIS other than root
