### PR TITLE
fixed null build status error

### DIFF
--- a/TeamCityMonitor.sln.DotSettings
+++ b/TeamCityMonitor.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/TeamCityMonitor/Repository/BuildMonitorRepository.cs
+++ b/TeamCityMonitor/Repository/BuildMonitorRepository.cs
@@ -47,7 +47,7 @@ namespace BuildMonitor.Repository
                                 ProjectId = proj.Id,
                                 BuildConfigName = currentConfig.Name,
                                 LastBuildTime = build.StartDate.ToString("dd/MM/yyyy HH:mm:ss"),
-                                LastBuildStatus = build.Status,
+                                LastBuildStatus = build.Status == null ? "unknown" : build.Status,  //sometimes the build status is null on projects new projects with zero builds
                                 LastBuildStatusText = build.StatusText
                             };
                             if (Properties.Settings.Default.ShowFailedBuildsOnly)


### PR DESCRIPTION
If a project has never been built, the status will return null.
added default value of 'unknown' when this happens.
